### PR TITLE
add a verify script to test a single exercise

### DIFF
--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -1,34 +1,14 @@
 #!/usr/bin/env bash
 
-# Synopsis:
-# Test the track's exercises.
-# 
-# At a minimum, this file must check if the example/exemplar solution of each 
-# Practice/Concept Exercise passes the exercise's tests.
-#
-# To check this, you usually have to (temporarily) replace the exercise's solution files
-# with its exemplar/example files.
-#
-# If your track uses skipped tests, make sure to (temporarily) enable these tests
-# before running the tests.
-#
-# The path to the solution/example/exemplar files can be found in the exercise's
-# .meta/config.json file, or possibly inferred from the exercise's directory name.
-
-# Example:
-# ./bin/test
-
 exit_code=0
 
 # Verify the Practice Exercises
 for practice_exercise_dir in ./exercises/practice/*/; do
-    if [ -d $practice_exercise_dir ]; then
-        echo -n "Checking $(basename "${practice_exercise_dir}") exercise..."
-        eui bin/run.ex $(basename "${practice_exercise_dir}") ${practice_exercise_dir} /tmp
-        echo -n $'\n'
-    	if [[ $(jq -r '. | .status' /tmp/results.json) != "pass" ]]; then
-            exit_code=1
-        fi
+    echo -n "Checking $(basename "${practice_exercise_dir}") exercise..."
+    eui bin/run.ex $(basename "${practice_exercise_dir}") ${practice_exercise_dir} /tmp
+    echo
+    if [[ $(jq -r '.status' /tmp/results.json) != "pass" ]]; then
+        ((exit_code++))
     fi
 done
 

--- a/bin/verify-one-exercise
+++ b/bin/verify-one-exercise
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+usage="usage: $0 exercise_directory
+
+Test one exercise.
+
+example: $0 ./exercises/practice/grains"
+
+usage() { echo "$usage" >&2; exit 1; }
+
+[[ $# -eq 1 && -d "$1" ]] || usage
+
+slug=$(basename "$1")
+if ! [[ -f "$1/${slug}.ex" && -f "$1/t_${slug}.e" ]]; then
+    echo "'$1' does not appear to contain an exercise" >&2
+    echo "" >&2
+    usage
+fi
+
+eui bin/run.ex "${slug}" "$1" /tmp
+
+echo
+echo
+cat /tmp/t_${slug}.out
+
+[[ $(jq -r '.status' /tmp/results.json) == "pass" ]]
+exit $?


### PR DESCRIPTION
Personally, I find it convenient for exercise development.

Small changes to the `verify_exercises` script:
* remove the outdated comment block
* no need to explicitly test with `-d`, the glob pattern ending with `/` does that
* `echo -n $'\n'` is exactly identical to the plain `echo`
* let the exit code count the number of failed exercises.