### PR TITLE
Fix typo in TESTS.md

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -4,7 +4,7 @@
  
 Simply type `eutest`. It is assumed that the path to the openeuphoria binaries has been declared in the PATH environment variable.
 
-See [Unit Testing][unt-testing] for comprehensive EUTEST documentation.
+See [Unit Testing][unit-testing] for comprehensive EUTEST documentation.
   
 ## Editing the t_*.e file
  


### PR DESCRIPTION
Noticed this issue on the website. Mark `rep/tiny` please.