### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams must be returned in alphabetic order.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 The anagrams must be returned in alphabetic order.

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Note
+
 Euphoria provides support for [optional parameters](https://openeuphoria.org/docs/lang_decl.html#_114_procedures).

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Note
+## Track specific instructions
 
 Euphoria provides support for [optional parameters](https://openeuphoria.org/docs/lang_decl.html#_114_procedures).


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.